### PR TITLE
fix: pointing source to right github url

### DIFF
--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -23,7 +23,7 @@ const Index = () => (
         {/* view <Link to="/stats">site statistics</Link>, {' '} */}
         or just <Link to="/contact">contact</Link> me.
       </p>
-      <p> Source available <a href="https://github.com/eschanet/eschanet.com">here</a>.</p>
+      <p> Source available <a href="https://github.com/eschanet/website.git">on my Github page</a>.</p>
     </article>
   </Main>
 );

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -29,7 +29,7 @@ const App = () => (
         {/* view <Link to="/stats">site statistics</Link>, {' '} */}
         or just <Link to="/contact">contact</Link> me.
       </p>
-      <p> Source available <a href="https://github.com/eschanet/eschanet.com">here</a>.</p>
+      <p> Source available <a href="https://github.com/eschanet/website.git">on my Github page</a>.</p>
     </article>
   </Main>
 );


### PR DESCRIPTION
Links to source on Github were still pointing to old URL. Fixed now.